### PR TITLE
Change expected object received as response to acknowledging orders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # CHANGELOG
 
+## 2018-04-21, Version 1.3.2, @kmcconnell
+
+### Notable Changes
+
+The return type of requests was updated to `Request.Promise` rather than `PromiseLike`.
+The `PromiseLike` type does not carry a `catch()` method, which meant parent modules
+could not chain catches onto the methods.
+
+Now when using the Orders methods, developers can add custom `.catch()`:
+
+```javascript
+WMT.Orders.getAllReleased({
+  // params
+})
+  .then((response: string) => {
+    // do something with the response
+  })
+  .catch((error: Error) => {
+    // handle the error.
+  });
+```
+
+- request:
+  - Changed return type of `execute` to `Promise` rather than `PromiseLike`,
+    which did not have the `.catch()` method available when imported into parent
+    modules. (Kane McConnell) #13
+- orders:
+  - Changed return type of all Orders methods to `Request.Promise` to pass through
+    the `.catch()` method to parent modules. (Kane McConnell) #13
+
 ## 2018-04-17, Version 1.3.1, @kmcconnell
 
 ### Notable Changes

--- a/lib/orders.d.ts
+++ b/lib/orders.d.ts
@@ -1,4 +1,5 @@
-﻿import * as Request from './request';
+﻿/// <reference types="bluebird" />
+import * as Request from './request';
 import * as PurchaseOrder from './orders/purchase';
 import * as Shipment from './orders/shipment';
 export { PurchaseOrder, Shipment };
@@ -57,7 +58,7 @@ export interface ShippingUpdateRequest extends Request.RequestHeaders {
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#getAllReleasedOrders}
  */
-export declare function getAllReleased(params: GetAllReleasedRequest): PromiseLike<any>;
+export declare function getAllReleased(params: GetAllReleasedRequest): Request.Promise<any>;
 /**
  * Acknowledge an entire order, including all of its order lines. Walmart requires a
  * seller to acknowledge orders within four hours of receipt of the order, except in
@@ -77,7 +78,7 @@ export declare function getAllReleased(params: GetAllReleasedRequest): PromiseLi
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#acknowledgingOrders}
  */
-export declare function ackOrder(params: AcknowledgeOrderRequest): PromiseLike<any>;
+export declare function ackOrder(params: AcknowledgeOrderRequest): Request.Promise<any>;
 /**
  * Updates the status of order lines to "Shipped" and triggers the charge to the
  * customer. Sellers must acknowledge your orders before sending a shipping update to
@@ -92,4 +93,4 @@ export declare function ackOrder(params: AcknowledgeOrderRequest): PromiseLike<a
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#shippingNotificationsUpdates}
  */
-export declare function postShippingUpdate(params: ShippingUpdateRequest): PromiseLike<any>;
+export declare function postShippingUpdate(params: ShippingUpdateRequest): Request.Promise<any>;

--- a/lib/request.d.ts
+++ b/lib/request.d.ts
@@ -1,4 +1,5 @@
-﻿import * as Config from './config';
+﻿/// <reference types="bluebird" />
+import * as Config from './config';
 import * as Promise from 'bluebird';
 export { Promise };
 /**
@@ -82,7 +83,7 @@ export interface RequestQuery {
  *
  * @return {Promise} Returns the response received from the Walmart Marketplace API.
  */
-export declare function execute(request: RequestParams): PromiseLike<any>;
+export declare function execute(request: RequestParams): Promise<any>;
 /**
  * Checks if the response includes a `statusCode` of `401`.
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmt-marketplace-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Walmart Marketplace API SDK",
   "main": "index.js",
   "directories": {

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -62,7 +62,7 @@ export interface ShippingUpdateRequest extends Request.RequestHeaders {
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#getAllReleasedOrders}
  */
-export function getAllReleased(params: GetAllReleasedRequest): PromiseLike<any> {
+export function getAllReleased(params: GetAllReleasedRequest): Request.Promise<any> {
   let requestParams: Request.RequestParams = {
     BaseUrl: 'https://marketplace.walmartapis.com/v3/orders/released',
     Query: {
@@ -98,7 +98,7 @@ export function getAllReleased(params: GetAllReleasedRequest): PromiseLike<any> 
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#acknowledgingOrders}
  */
-export function ackOrder(params: AcknowledgeOrderRequest): PromiseLike<any> {
+export function ackOrder(params: AcknowledgeOrderRequest): Request.Promise<any> {
   let requestParams: Request.RequestParams = {
     BaseUrl: `https://marketplace.walmartapis.com/v3/orders/${params.PurchaseOrderId}/acknowledge`,
     Method: 'POST',
@@ -124,7 +124,7 @@ export function ackOrder(params: AcknowledgeOrderRequest): PromiseLike<any> {
  *
  * @see {@link https://developer.walmart.com/#/apicenter/marketPlace/latest#shippingNotificationsUpdates}
  */
-export function postShippingUpdate(params: ShippingUpdateRequest): PromiseLike<any> {
+export function postShippingUpdate(params: ShippingUpdateRequest): Request.Promise<any> {
   let requestParams: Request.RequestParams = {
     BaseUrl: `https://marketplace.walmartapis.com/v3/orders/${params.PurchaseOrderId}/shipping`,
     Method: 'POST',

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -92,7 +92,7 @@ export interface RequestQuery {
  *
  * @return {Promise} Returns the response received from the Walmart Marketplace API.
  */
-export function execute(request: RequestParams): PromiseLike<any> {
+export function execute(request: RequestParams): Promise<any> {
   if (!Credentials) {
     throw new Error('Must set Request.Credentials before making a request.');
   }


### PR DESCRIPTION
- request:
  - Changed return type of `execute` to `Promise` rather than
    `PromiseLike`, which did not have the `.catch()` method available
    when imported into parent modules.
- orders:
  - Changed return type of all Orders methods to `Request.Promise` to
    pass through the `.catch()` method to parent modules.

Issue: https://github.com/makanaleu/wmt-marketplace-sdk/issues/13
Signed-off-by: Kane McConnell <kane@makanal.eu>
CLA: f863b4f7bdee7d6997520ecaf537ddf0